### PR TITLE
Make noise schedule indpendent of num steps

### DIFF
--- a/examples/reach_avoid.py
+++ b/examples/reach_avoid.py
@@ -83,7 +83,6 @@ def generate_dataset_from_demos(save: bool = False, plot: bool = False) -> None:
     langevin_options = AnnealedLangevinOptions(
         num_noise_levels=300,
         starting_noise_level=0.5,
-        noise_decay_rate=0.98,
         num_steps=100,
         step_size=0.01,
     )
@@ -100,7 +99,6 @@ def generate_dataset_from_demos(save: bool = False, plot: bool = False) -> None:
 
     # Generate the dataset
     sigma_L = langevin_options.starting_noise_level
-    gamma = langevin_options.noise_decay_rate
     L = langevin_options.num_noise_levels
 
     def scan_fn(rng: jax.random.PRNGKey, k: int):
@@ -110,7 +108,7 @@ def generate_dataset_from_demos(save: bool = False, plot: bool = False) -> None:
         U = U_demo[demo_idx]
 
         # Add noise to the demonstration
-        sigma = sigma_L * gamma ** (L - k - 1)
+        sigma = sigma_L * jnp.exp(-4 * (L - k) / L)
         rng, noise_rng = jax.random.split(rng)
         U_tilde = U + sigma * jax.random.normal(noise_rng, U.shape)
 
@@ -220,7 +218,6 @@ def generate_dataset(save: bool = False, plot: bool = False) -> None:
     langevin_options = AnnealedLangevinOptions(
         num_noise_levels=300,
         starting_noise_level=0.5,
-        noise_decay_rate=0.98,
         num_steps=100,
         step_size=0.01,
     )

--- a/tests/test_data_gen.py
+++ b/tests/test_data_gen.py
@@ -17,7 +17,6 @@ def test_score_estimate() -> None:
     langevin_options = AnnealedLangevinOptions(
         num_noise_levels=3,
         starting_noise_level=0.1,
-        noise_decay_rate=0.9,
         num_steps=4,
         step_size=0.1,
     )
@@ -56,7 +55,6 @@ def test_gen_from_state() -> None:
     langevin_options = AnnealedLangevinOptions(
         num_noise_levels=250,
         starting_noise_level=0.1,
-        noise_decay_rate=0.97,
         num_steps=8,
         step_size=0.1,
     )
@@ -98,7 +96,6 @@ def test_generate() -> None:
     langevin_options = AnnealedLangevinOptions(
         num_noise_levels=250,
         starting_noise_level=0.1,
-        noise_decay_rate=0.97,
         num_steps=8,
         step_size=0.1,
     )
@@ -131,7 +128,6 @@ def test_save_and_load() -> None:
     langevin_options = AnnealedLangevinOptions(
         num_noise_levels=250,
         starting_noise_level=0.1,
-        noise_decay_rate=0.97,
         num_steps=8,
         step_size=0.1,
     )

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -35,7 +35,6 @@ def test_training() -> None:
     langevin_options = AnnealedLangevinOptions(
         num_noise_levels=100,
         starting_noise_level=0.5,
-        noise_decay_rate=0.97,
         num_steps=10,
         step_size=0.01,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,7 +35,6 @@ def test_annealed_langevin_sample() -> None:
     options = AnnealedLangevinOptions(
         num_noise_levels=100,
         starting_noise_level=2.0,
-        noise_decay_rate=0.97,
         num_steps=50,
         step_size=0.01,
         noise_injection_level=1.0,


### PR DESCRIPTION
Simplifies the noise schedule to no longer depend on the total number of noise levels. 

Tried several noise schedules, including the cosine squared schedule recommended by Cheng. A simple exponential decay seemed to work best. 