### PR TITLE
Enforce input limits

### DIFF
--- a/examples/bug_trap.py
+++ b/examples/bug_trap.py
@@ -116,7 +116,7 @@ def generate_dataset(plot: bool = False) -> None:
     )
     langevin_options = AnnealedLangevinOptions(
         num_noise_levels=300,
-        starting_noise_level=1.0,
+        starting_noise_level=0.1,
         num_steps=100,
         step_size=0.01,
         noise_injection_level=1.0,

--- a/rddp/envs/bug_trap.py
+++ b/rddp/envs/bug_trap.py
@@ -53,6 +53,7 @@ class BugTrapEnv(PipelineEnv):
     def step(self, state: State, action: jnp.ndarray) -> State:
         """Forward dynamics, observation, and reward."""
         state.info["step"] += 1
+        action *= 10  # scale original actions
 
         # Dynamics
         q = state.pipeline_state.q
@@ -94,7 +95,7 @@ class BugTrapEnv(PipelineEnv):
         """
 
         def scan_fn(total_cost: float, obs_pos: jnp.ndarray):
-            cost = jnp.exp(-5 * jnp.linalg.norm(x[0:2] - obs_pos) ** 2)
+            cost = jnp.exp(-10 * jnp.linalg.norm(x[0:2] - obs_pos) ** 2)
             return total_cost + cost, None
 
         total_cost, _ = jax.lax.scan(scan_fn, 0.0, self.obs_positions)

--- a/rddp/ocp.py
+++ b/rddp/ocp.py
@@ -16,15 +16,17 @@ class OptimalControlProblem:
     distribution.
     """
 
-    def __init__(self, env: PipelineEnv, num_steps: int):
+    def __init__(self, env: PipelineEnv, num_steps: int, u_max: float = 1.0):
         """Initialize the optimal control problem.
 
         Args:
             env: The system to control (includes dynamics and reward/cost).
             num_steps: The number of time steps in the planning horizon.
+            u_max: The maximum control input magnitude.
         """
         self.env = env
         self.num_steps = num_steps
+        self.u_max = u_max
 
     def rollout(
         self, initial_state: State, control_tape: jnp.ndarray
@@ -42,7 +44,7 @@ class OptimalControlProblem:
 
         def scan_fn(carry: Tuple, t: int):
             x, cost = carry
-            u = control_tape[t]
+            u = self.u_max * jnp.tanh(control_tape[t] / self.u_max)
             x_next = self.env.step(x, u)
             cost -= x_next.reward
             return (x_next, cost), x

--- a/tests/test_ocp.py
+++ b/tests/test_ocp.py
@@ -27,7 +27,7 @@ def test_rollout() -> None:
     total_cost_manual = 0.0
     for i in range(ocp.num_steps):
         assert jnp.all(x.done == 0.0)
-        u = control_tape[i]
+        u = jnp.tanh(control_tape[i])
         x = env.step(x, u)
         total_cost_manual -= x.reward
     assert jnp.all(x.done == 1.0)


### PR DESCRIPTION
Adds input limits (default [-1, 1]) to all systems via the `OptimalControlProblem` rollout mechanism. 

This means that all environments will have input limits, but we don't need to directly modify each env. This brings us in closer alignment with Brax's PPO implementation, which samples actions from a normal-tanh distribution. 